### PR TITLE
feat: Human readable error message when expressions are built from wrong table.

### DIFF
--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -24,6 +24,8 @@ class SelectQueryBuilder {
 
   /// Builds the SQL query.
   String build() {
+    _validateTableReferences(_table, orderBy: _orderBy, where: _where);
+
     var join =
         _buildJoinQuery(where: _where, orderBy: _orderBy, include: _include);
 
@@ -132,6 +134,8 @@ class CountQueryBuilder {
 
   /// Builds the SQL query.
   String build() {
+    _validateTableReferences(_table, where: _where);
+
     var join = _buildJoinQuery(where: _where);
 
     var query = 'SELECT COUNT($_field)';
@@ -179,6 +183,8 @@ class DeleteQueryBuilder {
 
   /// Builds the SQL query.
   String build() {
+    _validateTableReferences(_table, where: _where);
+
     var using = _buildUsingQuery(where: _where);
 
     var query = 'DELETE FROM "$_table"';
@@ -348,4 +354,43 @@ _UsingQuery _usingQueryFromTableRelations(
     using: usingStatements.join(', '),
     where: whereStatements.join(' AND '),
   );
+}
+
+void _validateTableReferences(
+  String tableName, {
+  List<Order>? orderBy,
+  Expression? where,
+}) {
+  List<String> exceptions = [];
+  if (orderBy != null) {
+    for (var column in orderBy.map((e) => e.column)) {
+      if (!column.hasBaseTable(tableName)) {
+        exceptions.add('"orderBy" expression referencing column $column.');
+      }
+    }
+  }
+
+  if (where != null) {
+    var columns = where.nodes.whereType<Column>();
+    for (var column in columns) {
+      if (!column.hasBaseTable(tableName)) {
+        exceptions.add('"where" expression referencing column $column.');
+      }
+    }
+  }
+
+  if (exceptions.isNotEmpty) {
+    var errorMessage =
+        'Column references starting from other tables than "$tableName" are not supported. The following expressions need to be removed or modified:'
+        '\n${exceptions.join('\n')}';
+    throw FormatException(errorMessage);
+  }
+}
+
+extension _ColumnHelpers on Column {
+  /// Returns true if the column has the specified table as base table.
+  bool hasBaseTable(String table) {
+    // Regex matches '<tableName>_' and '<tableName>.'
+    return toString().startsWith(RegExp(table + r'[_\.]'));
+  }
 }


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod/issues/1312

Adds a more helpful error message if a "Where" or "OrderBy" column expression is built from another table than the one we are performing operations on.

### Where expression error example:
``` dart
Citizen.find(
  session,
  where: (_) =>
      Company.t.name.equals('Serverpod'),
);
```
Will give an exception with message: 
```
FormatException: Column references starting from other tables than "citizen" are not supported. The following expressions need to be removed or modified:
"where" expression referencing column company."name".
```

### OrderBy expression error example:
``` dart
Citizen.find(
  session,
  orderBy: Company.t.name,
);
```

Will give an exception with message: 
```
FormatException: Column references starting from other tables than "citizen" are not supported. The following expressions need to be removed or modified:
"orderBy" expression referencing column company."name".
```

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

-