### PR TITLE
Fix endpoint context comparison

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -40,11 +40,10 @@ class EndpointsAnalyzer {
   Future<bool> updateFileContexts(Set<String> filePaths) async {
     await _refreshContextForFiles(filePaths);
 
-    var oldDefinitions = _endpointDefinitions;
+    var oldDefinitionsLength = _endpointDefinitions.length;
     await analyze(collector: CodeGenerationCollector());
 
-    var shared = _endpointDefinitions.intersection(oldDefinitions);
-    if (shared.length != oldDefinitions.length) {
+    if (_endpointDefinitions.length != oldDefinitionsLength) {
       return true;
     }
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -180,7 +180,7 @@ class NewEndpoint extends Endpoint {
     return 'Hello \$name';
   });
 }
-  ''');
+''');
 
       await expectLater(
         analyzer.updateFileContexts({newEndpointFile.path}),

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -249,8 +249,9 @@ class ExampleEndpoint extends Endpoint {
 import 'package:serverpod/serverpod.dart';
 
 class ExampleEndpoint extends Endpoint {
-
-
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
 ''');
       analyzer = EndpointsAnalyzer(trackedDirectory);
       await analyzer.analyze(collector: CodeGenerationCollector());
@@ -295,6 +296,7 @@ import 'invalid_dart.dart';
 
 class ExampleClass extends Endpoint {
   Future<String> hello(Session session, String name) async {
+    InvalidClass example = InvalidClass();
     return 'Hello \$name';
   }
 }
@@ -302,9 +304,9 @@ class ExampleClass extends Endpoint {
       invalidDartFile =
           File(path.join(trackedDirectory.path, 'invalid_dart.dart'));
       invalidDartFile.createSync(recursive: true);
-      // Class is missing closing brackets
+      // Class keyword is combined with class name
       invalidDartFile.writeAsStringSync('''
-class MyClass {
+classInvalidClass {}
 ''');
       analyzer = EndpointsAnalyzer(trackedDirectory);
       await analyzer.analyze(collector: CodeGenerationCollector());
@@ -314,7 +316,7 @@ class MyClass {
         'when the file context is updated with a fix for the invalid dart file '
         'then true is returned.', () async {
       invalidDartFile.writeAsStringSync('''
-class MyClass {}
+class InvalidClass {}
 ''');
 
       await expectLater(

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -165,6 +165,28 @@ class ExampleClass {}
         completion(false),
       );
     });
+
+    test(
+        'when the file context is updated with a new endpoint file '
+        'then true is returned.', () async {
+      var newEndpointFile =
+          File(path.join(trackedDirectory.path, 'new_endpoint.dart'));
+      newEndpointFile.createSync(recursive: true);
+      newEndpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class NewEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  });
+}
+  ''');
+
+      await expectLater(
+        analyzer.updateFileContexts({newEndpointFile.path}),
+        completion(true),
+      );
+    });
   });
 
   group('Given a tracked and analyzed directory with valid non-endpoint file',

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -149,6 +149,22 @@ class ExampleEndpoint extends Endpoint {
         completion(true),
       );
     });
+
+    test(
+        'when the file context is updated with a non endpoint file '
+        'then false is returned.', () async {
+      var nonEndpointFile =
+          File(path.join(trackedDirectory.path, 'non_endpoint.dart'));
+      nonEndpointFile.createSync(recursive: true);
+      nonEndpointFile.writeAsStringSync('''
+class ExampleClass {}
+''');
+
+      await expectLater(
+        analyzer.updateFileContexts({nonEndpointFile.path}),
+        completion(false),
+      );
+    });
   });
 
   group('Given a tracked and analyzed directory with valid non-endpoint file',


### PR DESCRIPTION
Patch to existing PR that fixes an issue where detecting endpoint definition changes did not work as expected.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - modification to new behavior.