### PR TITLE
Fix issue 3611: correct wasm content type

### DIFF
--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -8,7 +8,7 @@ import 'package:serverpod/serverpod.dart';
 final _contentTypeMapping = <String, ContentType>{
   '.js': ContentType('text', 'javascript'),
   '.json': ContentType('application', 'json'),
-  '.wsam': ContentType('application', 'wasm'),
+  '.wasm': ContentType('application', 'wasm'),
   '.css': ContentType('text', 'css'),
   '.png': ContentType('image', 'png'),
   '.jpg': ContentType('image', 'jpeg'),


### PR DESCRIPTION
## Summary
- fix typo so `.wasm` files get the correct content type

## Testing
- `dart format --output=none --set-exit-if-changed packages/serverpod/lib/src/relic/routes/static_directory.dart` *(fails: `bash: dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684047f47bf88332846cd34e1b38cb5f